### PR TITLE
Add experiment scripts, visualization and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,45 @@
 
 ## 使用说明
 
+### 依赖环境
+
+以下版本在作者环境中验证通过：
+
+- Python 3.10
+- PyTorch 2.0.1
+- PyTorch-Geometric 2.3.1
+- NetworkX 3.1
+- Geopy 2.3.0
+- Matplotlib 3.7.1
+
 1. 推荐使用提供的一键脚本：`./run.sh`。脚本会自动安装依赖并执行训练，可将自然语言描述作为参数传入：
    `./run.sh --nl "希望房子便宜并靠近学校"`
 2. 若已安装好依赖，也可直接运行：`python train.py`
 3. 训练完成后可在命令行查看推荐结果或在生成的日志中获取模型指标。
+
+### 复现论文中的对比实验
+
+使用 `experiments.py` 可以分别运行加权排序(`weighted`)、仅进化(`evolution`)、仅强化学习(`rl`)以及混合方法(`hybrid`)四种模式：
+
+```bash
+python experiments.py weighted
+python experiments.py evolution
+python experiments.py rl
+python experiments.py hybrid
+```
+其中 `evolution` 和 `hybrid` 模式会在当前目录生成 `*_pareto.json` 及对应的 PNG 图像，用于展示帕累托前沿。
+
+### 实时交互演示
+
+`interactive_demo.py` 可以读取 `adjust_order.json` 中的自然语言描述或通过 `--nl` 直接指定描述，自动更新偏好并重新输出推荐结果：
+
+```bash
+python interactive_demo.py --nl "希望房子更大并靠近医院"
+```
+
+### English Overview
+
+This repository implements a multi-objective real estate recommender combining GNN, reinforcement learning and evolutionary search. Use `run.sh` or `python train.py` to train the full pipeline. `experiments.py` reproduces ablation studies and exports Pareto front data for visualization. `interactive_demo.py` demonstrates dynamic preference updating via natural language.
 
 ## 数据来源与授权
 

--- a/experiments.py
+++ b/experiments.py
@@ -1,0 +1,103 @@
+import argparse
+from data_loader import load_data
+from graph_builder import build_graph
+from gnn_model import train_gnn
+from evolutionary_optimizer import EvolutionaryOptimizer, optimize_with_hybrid
+from rl_agent import RLRanker
+from utils import rank_properties, calculate_score
+
+
+def prepare_embeddings(houses, schools, hospitals, state_dim=16):
+    graph = build_graph(houses, schools, hospitals)
+    embeddings = train_gnn(graph, embedding_dim=state_dim, epochs=50)
+    for h in houses:
+        hid = h['id']
+        if hid < len(embeddings):
+            h['embedding'] = embeddings[hid]
+        else:
+            h['embedding'] = [0.0] * state_dim
+
+
+def weighted_only():
+    houses, schools, hospitals, prefs, criteria = load_data(
+        'updated_houses_with_price_history.json',
+        'facilities.geojson',
+        'user_preferences.json',
+        'updated_criteria.json'
+    )
+    scored = rank_properties(houses, criteria, prefs.get('weights', {}), top_n=10)
+    print('Top results (weighted sort):')
+    for h, s in scored:
+        print(h.get('address'), s)
+
+
+def evolution_only():
+    houses, schools, hospitals, prefs, criteria = load_data(
+        'updated_houses_with_price_history.json',
+        'facilities.geojson',
+        'user_preferences.json',
+        'updated_criteria.json'
+    )
+    optimizer = EvolutionaryOptimizer(criteria)
+    front = optimizer.optimize_nsga2(houses)
+    scored = rank_properties(front, criteria, prefs.get('weights', {}), top_n=10)
+    optimizer.export_front_points(front, 'evolution_pareto.json')
+    print('Top results (evolution only):')
+    for h, s in scored:
+        print(h.get('address'), s)
+
+
+def rl_only():
+    houses, schools, hospitals, prefs, criteria = load_data(
+        'updated_houses_with_price_history.json',
+        'facilities.geojson',
+        'user_preferences.json',
+        'updated_criteria.json'
+    )
+    prepare_embeddings(houses, schools, hospitals)
+    ranker = RLRanker(criteria, prefs, state_dim=16)
+    ranker.train(houses, episodes=50, verbose=True)
+    ranked = ranker.rank(houses)[:10]
+    print('Top results (RL only):')
+    for h in ranked:
+        score = calculate_score(h, criteria, prefs.get('weights', {}))
+        print(h.get('address'), score)
+
+
+def hybrid():
+    houses, schools, hospitals, prefs, criteria = load_data(
+        'updated_houses_with_price_history.json',
+        'facilities.geojson',
+        'user_preferences.json',
+        'updated_criteria.json'
+    )
+    candidates = optimize_with_hybrid(houses, criteria, save_pareto_path='hybrid_pareto.json')
+    if not candidates:
+        candidates = houses
+    prepare_embeddings(candidates, schools, hospitals)
+    ranker = RLRanker(criteria, prefs, state_dim=16)
+    ranker.train(candidates, episodes=50, verbose=True)
+    ranked = ranker.rank(candidates)[:10]
+    print('Top results (hybrid):')
+    for h in ranked:
+        score = calculate_score(h, criteria, prefs.get('weights', {}))
+        print(h.get('address'), score)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Run comparison experiments')
+    parser.add_argument('mode', choices=['weighted', 'evolution', 'rl', 'hybrid'])
+    args = parser.parse_args()
+
+    if args.mode == 'weighted':
+        weighted_only()
+    elif args.mode == 'evolution':
+        evolution_only()
+    elif args.mode == 'rl':
+        rl_only()
+    else:
+        hybrid()
+
+
+if __name__ == '__main__':
+    main()

--- a/interactive_demo.py
+++ b/interactive_demo.py
@@ -1,0 +1,56 @@
+import argparse
+import json
+from data_loader import load_user_preferences, load_criteria, load_data
+from utils import parse_natural_language, apply_adjustments, calculate_score
+from evolutionary_optimizer import optimize_with_hybrid
+from graph_builder import build_graph
+from gnn_model import train_gnn
+from rl_agent import RLRanker
+
+
+def run_pipeline():
+    houses, schools, hospitals, prefs, criteria = load_data(
+        'updated_houses_with_price_history.json',
+        'facilities.geojson',
+        'user_preferences.json',
+        'updated_criteria.json'
+    )
+    candidates = optimize_with_hybrid(houses, criteria)
+    if not candidates:
+        candidates = houses
+    graph = build_graph(candidates, schools, hospitals)
+    embeddings = train_gnn(graph, embedding_dim=16, epochs=50)
+    for h in candidates:
+        hid = h['id']
+        h['embedding'] = embeddings[hid] if hid < len(embeddings) else [0.0] * 16
+    ranker = RLRanker(criteria, prefs, state_dim=16)
+    ranker.train(candidates, episodes=50, verbose=True)
+    ranked = ranker.rank(candidates)[:5]
+    for h in ranked:
+        score = calculate_score(h, criteria, prefs.get('weights', {}))
+        print(h.get('address'), score)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Interactive preference update')
+    parser.add_argument('--file', default='adjust_order.json', help='JSON file containing natural language description')
+    parser.add_argument('--nl', type=str, help='Natural language text directly')
+    args = parser.parse_args()
+
+    if args.nl:
+        text = args.nl
+    else:
+        with open(args.file, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+            text = data.get('text', '')
+
+    prefs = load_user_preferences('user_preferences.json')
+    crit = load_criteria('updated_criteria.json')
+    adj = parse_natural_language(text)
+    apply_adjustments(crit, prefs, adj)
+
+    run_pipeline()
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-torch
-torch-geometric
-networkx
-geopy
+torch==2.0.1
+torch-geometric==2.3.1
+networkx==3.1
+geopy==2.3.0
+matplotlib==3.7.1

--- a/rl_agent.py
+++ b/rl_agent.py
@@ -104,8 +104,11 @@ class RLRanker:
         self.weights = preferences.get('weights', {})
         self.agent = DQNAgent(state_dim)
 
-    def train(self, houses: List[dict], episodes: int = 50):
-        for _ in range(episodes):
+    def train(self, houses: List[dict], episodes: int = 50, verbose: bool = False) -> list:
+        """训练 DQN 并返回每个 episode 的累积奖励"""
+        episode_rewards = []
+        for ep in range(episodes):
+            total = 0.0
             random.shuffle(houses)
             for i, house in enumerate(houses):
                 state = torch.tensor(house['embedding'], dtype=torch.float)
@@ -115,6 +118,11 @@ class RLRanker:
                 next_state = torch.tensor(houses[(i + 1) % len(houses)]['embedding'], dtype=torch.float)
                 self.agent.store(state, action, reward, next_state, float(done))
                 self.agent.train_step()
+                total += reward
+            episode_rewards.append(total)
+            if verbose:
+                print(f'Episode {ep + 1}: reward={total:.2f}')
+        return episode_rewards
 
     def rank(self, houses: List[dict]) -> List[dict]:
         scored = []


### PR DESCRIPTION
## Summary
- add versioned requirements
- implement Pareto front export and plotting
- collect RL training rewards
- add comparison experiment runner and interactive demo
- extend README with usage, ablation instructions and English overview

## Testing
- `python -m py_compile data_loader.py evolutionary_optimizer.py gnn_model.py graph_builder.py rl_agent.py utils.py train.py experiments.py interactive_demo.py`