### PR TITLE
Add evaluation visualizations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ torch-geometric==2.3.1
 networkx==3.1
 geopy==2.3.0
 matplotlib==3.7.1
+numpy==1.25.2


### PR DESCRIPTION
## Summary
- add numpy dependency
- extend evaluation with helper functions for radar chart, bar charts, and 3D Pareto plots
- compute hypervolume and coverage metrics
- output comparison plots and radar charts for top results

## Testing
- `python -m py_compile evaluation.py`
- `python evaluation.py --out tmp_eval` *(fails: ModuleNotFoundError: No module named 'numpy')*