### PR TITLE
Add CPU threads option to scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@
 
 1. 推荐使用提供的一键脚本：`./run.sh`。脚本会自动安装依赖并执行训练，可将自然语言描述作为参数传入：
    `./run.sh --nl "希望房子便宜并靠近学校"`
-2. 若已安装好依赖，也可直接运行：`python train.py`
-3. 训练完成后可在命令行查看推荐结果或在生成的日志中获取模型指标。
+2. 若已安装好依赖，也可直接运行：`python train.py [--threads N]`
+3. 可通过 `--threads` 指定 CPU 线程数，默认 8。
+4. 训练完成后可在命令行查看推荐结果或在生成的日志中获取模型指标。
 
 ### 复现论文中的对比实验
 
@@ -86,13 +87,13 @@ python interactive_demo.py --nl "希望房子更大并靠近医院"
 使用 `evaluation.py` 可一次性运行四种方法并生成评测指标及训练曲线到指定目录：
 
 ```bash
-python evaluation.py --out eval_plots
+python evaluation.py --out eval_plots [--threads N]
 ```
 
 
 ### English Overview
 
-This repository implements a multi-objective real estate recommender combining GNN, reinforcement learning and evolutionary search. Use `run.sh` or `python train.py` to train the full pipeline. `experiments.py` reproduces ablation studies and exports Pareto front data for visualization. `interactive_demo.py` demonstrates dynamic preference updating via natural language.
+This repository implements a multi-objective real estate recommender combining GNN, reinforcement learning and evolutionary search. Use `run.sh` or `python train.py [--threads N]` to train the full pipeline. `experiments.py` reproduces ablation studies and exports Pareto front data for visualization. `interactive_demo.py` demonstrates dynamic preference updating via natural language.
 
 ## 数据来源与授权
 

--- a/evaluation.py
+++ b/evaluation.py
@@ -7,9 +7,6 @@ import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
 import torch
 
-torch.set_num_threads(8)
-os.environ.setdefault("OMP_NUM_THREADS", "8")
-
 from data_loader import load_data
 from utils import calculate_score, rank_properties
 from evolutionary_optimizer import EvolutionaryOptimizer, optimize_with_hybrid
@@ -237,7 +234,11 @@ def run_evaluation(output_dir):
 def main():
     parser = argparse.ArgumentParser(description='Evaluate all methods')
     parser.add_argument('--out', default='eval_plots', help='Output directory')
+    parser.add_argument('--threads', type=int, default=8,
+                        help='Number of CPU threads to use')
     args = parser.parse_args()
+    torch.set_num_threads(args.threads)
+    os.environ["OMP_NUM_THREADS"] = str(args.threads)
     run_evaluation(args.out)
 
 

--- a/mass_evaluate.py
+++ b/mass_evaluate.py
@@ -4,6 +4,7 @@ import json
 import numpy as np
 import matplotlib.pyplot as plt
 import torch
+import argparse
 
 from data_loader import load_houses, load_facilities, filter_houses
 from utils import compute_statistics, normalize_features, rank_properties, calculate_score
@@ -12,9 +13,6 @@ from rl_agent import RLRanker
 from graph_builder import build_graph
 from gnn_model import train_gnn
 from evaluation import evaluate_ranking
-
-torch.set_num_threads(8)
-os.environ.setdefault("OMP_NUM_THREADS", "8")
 
 
 def generate_random_prefs(stats, house_types):
@@ -71,6 +69,15 @@ def evaluate_one(all_houses, schools, hospitals, weights, criteria):
 
 
 def main():
+    parser = argparse.ArgumentParser(
+        description='Run random preference evaluations')
+    parser.add_argument('--threads', type=int, default=8,
+                        help='Number of CPU threads to use')
+    args = parser.parse_args()
+
+    torch.set_num_threads(args.threads)
+    os.environ["OMP_NUM_THREADS"] = str(args.threads)
+
     all_houses = load_houses('updated_houses_with_price_history.json')
     schools, hospitals = load_facilities('facilities.geojson')
     stats_all = compute_statistics(all_houses)

--- a/train.py
+++ b/train.py
@@ -4,9 +4,6 @@ from pprint import pprint
 import os
 import torch
 
-torch.set_num_threads(8)
-os.environ.setdefault("OMP_NUM_THREADS", "8")
-
 from data_loader import load_data, load_user_preferences, load_criteria
 from graph_builder import build_graph
 from gnn_model import train_gnn
@@ -18,7 +15,12 @@ from utils import parse_natural_language, apply_adjustments, calculate_score
 def main():
     parser = argparse.ArgumentParser(description="Train real estate recommender")
     parser.add_argument('--nl', type=str, help='\u81ea\u7136\u8bed\u8a00\u504f\u597d\u63cf\u8ff0')
+    parser.add_argument('--threads', type=int, default=8,
+                        help='Number of CPU threads to use')
     args = parser.parse_args()
+
+    torch.set_num_threads(args.threads)
+    os.environ["OMP_NUM_THREADS"] = str(args.threads)
 
     if args.nl:
         prefs = load_user_preferences('user_preferences.json')


### PR DESCRIPTION
## Summary
- make train.py, evaluation.py and mass_evaluate.py accept `--threads` to set CPU threads
- set `torch.set_num_threads` and `OMP_NUM_THREADS` using the value
- document the new option in README

## Testing
- `python -m py_compile train.py evaluation.py mass_evaluate.py`