### PR TITLE
Enable multi-run evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ python interactive_demo.py --nl "希望房子更大并靠近医院"
 python evaluation.py --out eval_plots
 ```
 
+如需多次随机生成偏好后求平均结果，可指定 `--num-runs`：
+
+```bash
+python evaluation.py --out eval_plots --num-runs 5
+```
+平均指标会写入 `average_metrics.json`，并在输出目录生成对应的柱状图。
+
 
 ### English Overview
 


### PR DESCRIPTION
## Summary
- add random preference generator and multi-run support in `evaluation.py`
- write averaged metrics to JSON and bar charts when using `--num-runs`
- document new evaluation option in README

## Testing
- `python -m py_compile evaluation.py`